### PR TITLE
Dannydev/paper

### DIFF
--- a/src/samples/paperTraderDemo.ts
+++ b/src/samples/paperTraderDemo.ts
@@ -46,7 +46,7 @@ GDAX.FeedFactory(logger, ['BTC-USD']).then((feed: ExchangeFeed) => {
         if (msg.side === 'buy') {
             deltaChange = Big(msg.tradeSize);
         } else if (msg.side === 'sell') {
-            deltaChange = Big(msg.tradeSize).mul(-1);
+            deltaChange = Big(msg.tradeSize).neg();
         }
         // if delta has not been previously defined
         if (newDelta === undefined) {


### PR DESCRIPTION
This PR fixes some small suggestions that exist on the [current feature PR](https://github.com/coinbase/gdax-tt/pull/236).

@jleonelion the only thing I'm really not sure about is your changes to `Trader.ts`  with the renaming of `placeOrder` and `cancelOrder`, then routing them to the original functions in a switch statement. I did try reverting that module back to the current master `Trader.ts` but then I get errors like:

```
2018-05-30T00:37:37.674Z - error: Total size should be zero at level $7478.13 but was 1.
```

When running the demo. Though, strangely enough, the unit tests pass.

However, I do agree with @blair, this is probably not something that should be renamed as it would break any current builds in the wild using the `placeOrder` public method. Plus I doubt we'd get this feature merged with those methods renamed.

Thoughts?